### PR TITLE
Fix CI

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,1 +1,1 @@
-requests-mock
+requests-mock<1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-opsgenie-sdk
-


### PR DESCRIPTION
The requests-mock library released v1.7.0, which wasn't supposed to break anything, but it broke our CI.

I also removed the opsgenie-sdk package since it isn't used anywhere, so it's just a distracting rabbit hole when you're trying to troubleshoot anything.