### PR TITLE
Add config option to support eu region for OpsGenie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm
+.idea/*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 0.4
+## 0.4.0
 
 - Add config option for region and update API URL when it's set to eu (Fixes: #12).
 
-## 0.3
+## 0.3.0
 
 - Update actions and action tests for OpsGenie v2.
 
@@ -12,10 +12,10 @@
 
 - Added example configuration file
 
-## 0.2
+## 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.
 
-## 0.1
+## 0.1.0
 
 - First release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4
+
+- Add config option for region and update API URL when it's set to eu (Fixes: #12).
+
 ## 0.3
 
 - Update actions and action tests for OpsGenie v2.

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -33,8 +33,10 @@ class OpsGenieBaseAction(Action):
         except KeyError:
             raise ValueError("api_key needs to be configured!")
 
-        if self.config.get("region") == "eu":
-            self.API_HOST = "https://api.eu.opsgenie.com/"
+        if self.config.get("region"):
+            self.API_HOST = "https://api.{region}.opsgenie.com/".format(
+                region=self.config.get("region")
+            )
 
     def _url(self, uri):
         """

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -33,6 +33,9 @@ class OpsGenieBaseAction(Action):
         except KeyError:
             raise ValueError("api_key needs to be configured!")
 
+        if self.config.get("region") == "eu":
+            self.API_HOST = "https://api.eu.opsgenie.com/"
+
     def _url(self, uri):
         """
         """

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -10,4 +10,4 @@ region:
     OpsGenie documentation for the complete list of API regions
   type: "string"
   required: false
-  default: "us"
+  default: ~

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -4,3 +4,10 @@ api_key:
   type: "string"
   secret: true
   required: true
+region:
+  description: "The service region for your OpsGenie account"
+  type: "string"
+  enum:
+    - "eu"
+    - "us"
+  default: "us"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -10,4 +10,4 @@ region:
     OpsGenie documentation for the complete list of API regions
   type: "string"
   required: false
-  default: ~
+  default: null

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -5,7 +5,9 @@ api_key:
   secret: true
   required: true
 region:
-  description: "The service region for your OpsGenie account"
+  description: >-
+    The service region for your OpsGenie account - check the
+    OpsGenie documentation for the complete list of API regions
   type: "string"
   enum:
     - "eu"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -9,7 +9,5 @@ region:
     The service region for your OpsGenie account - check the
     OpsGenie documentation for the complete list of API regions
   type: "string"
-  enum:
-    - "eu"
-    - "us"
+  required: false
   default: "us"

--- a/opsgenie.yaml.example
+++ b/opsgenie.yaml.example
@@ -1,2 +1,3 @@
 ---
 api_key: "334040f93f3f30f3"
+region: "eu"

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
     - alerting
     - monitoring
 version: 0.4.0
-author: Jon Middleton
-email: jon.middleton@pulsant.com
+author: StackStorm, Inc.
+email: info@stackstorm.com
 contributors:
   - Jon Middleton <jjm@geeky-and-blonde.me.uk>

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
     - OpsGenie
     - alerting
     - monitoring
-version: 0.3.2
+version: 0.4.0
 author: Jon Middleton
 email: jon.middleton@pulsant.com
 contributors:


### PR DESCRIPTION
- Add `.idea` to `.gitignore`.
- Add config option for region and update API URL when it's set to `eu` (Fixes: #12).
- Update author and email to be stackstorm from me (Fixes: #9).